### PR TITLE
Add CI workflow for software testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+name: Software Testing CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Validate Prisma schema
+        run: npx prisma validate


### PR DESCRIPTION
this is smaller workflow for first CI pipeline

later plan after our group add a testing framework and TypeScript setup, upgrade it to:
- name: Type check
  run: npm run typecheck

- name: Run unit tests
  run: npm test
  
  
 NOW
GitHub Actions
├── npm ci
└── Prisma validation

NEXT
├── TypeScript type checking
└── npm test

LATER
├── calculateMatchScore tests
├── classifyMatch tests
├── Boundary Value tests
├── claim tests
└── integration tests